### PR TITLE
Fix quic-go context params

### DIFF
--- a/network/quic.go
+++ b/network/quic.go
@@ -3,6 +3,7 @@ package network
 import (
 	"bytes"
 	"compress/gzip"
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/tls"
@@ -72,7 +73,7 @@ func (t *QuicTransport) Dial() (Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	stm, err := sess.OpenUniStreamSync()
+	stm, err := sess.OpenUniStreamSync(context.Background())
 	if err != nil {
 		return nil, err
 	}
@@ -112,11 +113,11 @@ func (t *QuicTransport) Listen() error {
 }
 
 func (t *QuicTransport) Accept() (Client, error) {
-	sess, err := t.listener.Accept()
+	sess, err := t.listener.Accept(context.Background())
 	if err != nil {
 		return nil, err
 	}
-	stm, err := sess.AcceptUniStream()
+	stm, err := sess.AcceptUniStream(context.Background())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The reversion back to quic-go v0.11.2 in commit 654d87b1 failed to add back the context parameters to a handful of functions in network/quic.go, breaking the build.