### PR TITLE
Fix panic when no neighbor connected

### DIFF
--- a/kernel/queue.go
+++ b/kernel/queue.go
@@ -65,6 +65,9 @@ func (node *Node) LoopCacheQueue() error {
 		}
 
 		neighbors := node.Peer.Neighbors()
+		if len(neighbors) <= 0 {
+			continue
+		}
 		var stale []crypto.Hash
 		err := node.persistStore.CacheListTransactions(func(tx *common.VersionedTransaction) error {
 			hash := tx.PayloadHash()


### PR DESCRIPTION
call to rand.Intn(n) panic when n is zero
