### PR TITLE
docs: Fix grammar issue in instructions for archive mode setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ To start a node, create a directory `mixin` for the config and network data file
 
 The main net genesis.json, nodes.json and an example config.example.toml files can be obtained from [here](https://github.com/MixinNetwork/mixin/tree/master/config), you only need to put your own signer spend key in the config.toml file.
 
-Change the `consensus-only` option to `false` will allow the node to start in archive mode, which syncs all the graph data.
+Changing the `consensus-only` option to `false` will allow the node to start in archive mode, which syncs all the graph data.
 
 ```
 $ mixin help kernel


### PR DESCRIPTION
This update corrects a grammatical error in the documentation under the section describing how to enable archive mode for a node. Previously, the line read:

> Change the `consensus-only` option to `false` will allow the node to start in archive mode, which syncs all the graph data.

This phrasing was incorrect because "Change" should be "Changing" to ensure grammatical consistency with the rest of the sentence. The corrected version now reads:

> Changing the `consensus-only` option to `false` will allow the node to start in archive mode, which syncs all the graph data.

**Thanks for Mixin!**
