### PR TITLE
refactor: use maps.Clone to simplify the code and reorder packages

### DIFF
--- a/kernel/node.go
+++ b/kernel/node.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+	"maps"
 	"math"
 	"sort"
 	"strings"
@@ -628,9 +629,5 @@ func (s *syncMap) Map() map[crypto.Hash]*p2p.SyncPoint {
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
 
-	m := make(map[crypto.Hash]*p2p.SyncPoint)
-	for k, p := range s.m {
-		m[k] = p
-	}
-	return m
+	return maps.Clone(s.m)
 }


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/maps@go1.21.1#Clone) added in the go1.21 standard library, which can make the code more concise and easy to read.