### PR TITLE
ci: bump golangci-lint-action to v8

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -25,7 +25,7 @@ jobs:
           go-version: '1.24'
           cache: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v8
         with:
           # Require: The version of golangci-lint to use.
           # When `install-mode` is `binary` (default) the value can be v1.2 or v1.2.3 or `latest` to use the latest version.


### PR DESCRIPTION
Maintenance update: switch all jobs to golangci-lint-action@v8 for better performance and compatibility. Pure maintenance, behavior unchanged. More details in the [v8.0.0 release](https://github.com/golangci/golangci-lint-action/releases/tag/v8.0.0).