### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/crypto/batch.go
+++ b/crypto/batch.go
@@ -56,10 +56,7 @@ func (v *BatchVerifier) add(publicKey *Key, message, sig []byte) {
 	// R_bytes is the first 32 bytes of the signature, but because the signature
 	// is passed as a variable-length array it could be too short. In that case
 	// we'll fail in Verify, so just avoid a panic here.
-	n := 32
-	if len(sig) < n {
-		n = len(sig)
-	}
+	n := min(len(sig), 32)
 	h.Write(sig[:n])
 
 	h.Write(publicKey[:])

--- a/util/base58/base58.go
+++ b/util/base58/base58.go
@@ -48,10 +48,7 @@ func Decode(b string) []byte {
 	// Of course, in addition, we'll need to handle boundary condition when `b` is not multiple of 58^10.
 	// In that case we'll use the bigRadix[n] lookup for the appropriate power.
 	for t := b; len(t) > 0; {
-		n := len(t)
-		if n > 10 {
-			n = 10
-		}
+		n := min(len(t), 10)
 
 		total := uint64(0)
 		for _, v := range t[:n] {


### PR DESCRIPTION
In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.