### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/mixin-test.yml
+++ b/.github/workflows/mixin-test.yml
@@ -1,4 +1,6 @@
 name: Mixin Test
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/MixinNetwork/mixin/security/code-scanning/8](https://github.com/MixinNetwork/mixin/security/code-scanning/8)

To fix the issue, add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function. Based on the provided workflow, it appears that the workflow only needs to read repository contents (e.g., for checking out the code) and does not require write permissions. Therefore, the `permissions` block should be set to `contents: read`.

The `permissions` block should be added at the top level of the workflow file, just below the `name` field, to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
