### PR TITLE
Fix broken link to 0-stor project in README

### DIFF
--- a/vendor/github.com/dgraph-io/badger/v4/README.md
+++ b/vendor/github.com/dgraph-io/badger/v4/README.md
@@ -181,7 +181,7 @@ Below is a list of known projects that use Badger:
 * [Sloop](https://github.com/salesforce/sloop) - Salesforce's Kubernetes History Visualization Project.
 * [Usenet Express](https://usenetexpress.com/) - Serving over 300TB of data with Badger.
 * [gorush](https://github.com/appleboy/gorush) - A push notification server written in Go.
-* [0-stor](https://github.com/zero-os/0-stor) - Single device object store.
+* [0-stor](https://github.com/threefoldtecharchive/0-stor) - Single device object store.
 * [Dispatch Protocol](https://github.com/dispatchlabs/disgo) - Blockchain protocol for distributed application data analytics.
 * [GarageMQ](https://github.com/valinurovam/garagemq) - AMQP server written in Go.
 * [RedixDB](https://alash3al.github.io/redix/) - A real-time persistent key-value store with the same redis protocol.


### PR DESCRIPTION
The link to the 0-stor project in the "Projects Using Badger" section was outdated and no longer working. Updated the URL to point to the archived repository at https://github.com/threefoldtecharchive/0-stor, ensuring users can access the correct project reference.