### PR TITLE
Use presence for all fields in codec_message_opaque

### DIFF
--- a/vendor/google.golang.org/protobuf/internal/impl/codec_message_opaque.go
+++ b/vendor/google.golang.org/protobuf/internal/impl/codec_message_opaque.go
@@ -73,18 +73,11 @@ func (mi *MessageInfo) makeOpaqueCoderMethods(t reflect.Type, si opaqueStructInf
 			presenceIndex: noPresence,
 		}
 
-		// TODO: Use presence for all fields.
-		//
-		// In some cases, such as maps, presence means only "might be set" rather
-		// than "is definitely set", but every field should have a presence bit to
-		// permit us to skip over definitely-unset fields at marshal time.
+		// Presence is now used for all fields.
+		cf.presenceIndex, mi.presenceSize = presenceIndex(mi.Desc, fd)
 
-		var hasPresence bool
-		hasPresence, cf.isLazy = usePresenceForField(si, fd)
-
-		if hasPresence {
-			cf.presenceIndex, mi.presenceSize = presenceIndex(mi.Desc, fd)
-		}
+		// isLazy is still determined as before
+		_, cf.isLazy = usePresenceForField(si, fd)
 
 		mi.orderedCoderFields = append(mi.orderedCoderFields, cf)
 		mi.coderFields[cf.num] = cf


### PR DESCRIPTION
Remove conditional presence logic and always assign a presence index for every field in MessageInfo.makeOpaqueCoderMethods. This ensures that all fields, regardless of type or options, have a presence bit, allowing the marshaler to efficiently skip unset fields. The determination of isLazy remains unchanged and is still based on usePresenceForField.