### PR TITLE
refactor: use b.Loop() to simplify the code and improve performance

### DIFF
--- a/util/base58/base58bench_test.go
+++ b/util/base58/base58bench_test.go
@@ -20,28 +20,28 @@ var (
 
 func BenchmarkBase58Encode_5K(b *testing.B) {
 	b.SetBytes(int64(len(raw5k)))
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		base58.Encode(raw5k)
 	}
 }
 
 func BenchmarkBase58Encode_100K(b *testing.B) {
 	b.SetBytes(int64(len(raw100k)))
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		base58.Encode(raw100k)
 	}
 }
 
 func BenchmarkBase58Decode_5K(b *testing.B) {
 	b.SetBytes(int64(len(encoded5k)))
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		base58.Decode(encoded5k)
 	}
 }
 
 func BenchmarkBase58Decode_100K(b *testing.B) {
 	b.SetBytes(int64(len(encoded100k)))
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		base58.Decode(encoded100k)
 	}
 }


### PR DESCRIPTION
These changes use b.Loop() to simplify the code and improve performance
Supported by Go Team, more info: [https://go.dev/blog/testing-b-loop ](https://go.dev/blog/testing-b-loop%C2%A0)


Before:

```shell
 go test -run=^$ -bench=. ./util/base58                   
goos: darwin
goarch: arm64
pkg: github.com/MixinNetwork/mixin/util/base58
cpu: Apple M4
BenchmarkBase58Encode_5K-10      	    1257	    958575 ns/op	   5.22 MB/s
BenchmarkBase58Encode_100K-10    	       3	 377777069 ns/op	   0.26 MB/s
BenchmarkBase58Decode_5K-10      	   13212	     91630 ns/op	  74.53 MB/s
BenchmarkBase58Decode_100K-10    	      42	  28674206 ns/op	   4.76 MB/s
PASS
ok  	github.com/MixinNetwork/mixin/util/base58	8.076s
```

After:

```shell
go test -run=^$ -bench=. ./util/base58   
goos: darwin
goarch: arm64
pkg: github.com/MixinNetwork/mixin/util/base58
cpu: Apple M4
BenchmarkBase58Encode_5K-10      	    1269	    945163 ns/op	   5.29 MB/s
BenchmarkBase58Encode_100K-10    	       3	 378859333 ns/op	   0.26 MB/s
BenchmarkBase58Decode_5K-10      	   13183	     91083 ns/op	  74.98 MB/s
BenchmarkBase58Decode_100K-10    	      40	  28572274 ns/op	   4.78 MB/s
PASS
ok  	github.com/MixinNetwork/mixin/util/base58	5.387s
```