### PR TITLE
ci: bump actions/checkout to v6

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -19,7 +19,7 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-go@v5
         with:
           go-version: '1.25'

--- a/.github/workflows/mixin-test.yml
+++ b/.github/workflows/mixin-test.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Setup Go
         uses: actions/setup-go@v5


### PR DESCRIPTION
Upgrade to actions/checkout v6 for latest improvements and security fixes.

https://github.com/actions/checkout/releases/tag/v6.0.0