### PR TITLE
fix: add SECURITY.md with formal VDP and triage SLA

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,45 @@
+# Security Policy
+
+## Supported Versions
+
+We release patches for security vulnerabilities. Which versions are eligible for receiving such patches depends on the CVSS v3.0 Rating:
+
+| CVSS v3.0 | Supported Versions                        |
+| --------- | ----------------------------------------- |
+| 9.0-10.0  | Releases within the past 12 months        |
+| 4.0-8.9   | Most recent release                       |
+
+## Reporting a Vulnerability
+
+We take the security of Mixin Network seriously. If you believe you have found a security vulnerability, please report it to us as described below.
+
+**Please do NOT report security vulnerabilities through public GitHub issues.**
+
+Instead, please report them via GitHub Security Advisories (GHSA) by clicking the "Security" tab and selecting "Report a vulnerability".
+
+When reporting a vulnerability, please include:
+- A detailed description of the vulnerability.
+- Steps to reproduce the issue or a Proof of Concept (PoC).
+- An assessment of the potential impact.
+- Any suggested remediation steps.
+
+## What to Expect (SLA)
+
+We are committed to acknowledging, triaging, and communicating about serious submissions within a reasonable timeframe.
+
+- **Acknowledgment:** We will acknowledge receipt of your vulnerability report within **48 hours**.
+- **Triage & ETA:** We will provide an initial triage assessment and a timeline for resolution within **5 business days**.
+- **Updates:** We will keep you informed of our progress and any changes to the status.
+
+If you do not receive a response within these timeframes, please feel free to follow up. We may receive a high volume of low-quality or AI-generated reports; however, legitimate security reports will always be prioritized and handled according to this SLA.
+
+## Bug Bounty Program
+
+Mixin Network operates a Bug Bounty Program with rewards of up to **$1,000,000** for critical vulnerabilities.
+
+- Vulnerabilities must be original and previously unreported.
+- The vulnerability must exist in a system or asset that is explicitly in scope for the program.
+- Rewards are paid out based on the severity of the vulnerability (using the CVSS v3.0 scale) and the quality of the report.
+- Responsible disclosure is strictly required. Public disclosure before a fix is deployed will disqualify the report from bounty rewards.
+
+For full details on the Bug Bounty Program scope, rules, and reward tiers, please visit our official Bug Bounty page.


### PR DESCRIPTION
## Summary

This PR introduces a formal `SECURITY.md` file to establish a clear Vulnerability Disclosure Policy (VDP) and explicit Service Level Agreements (SLAs) for security researchers.

This addresses the concerns raised in #216 regarding the lack of communication and triage timelines for privately submitted GitHub Security Advisories (GHSAs). While filtering spam and AI-generated reports is necessary, legitimate and critical vulnerabilities require a structured and responsive process.

## Changes

- Added `SECURITY.md` to the repository root.
- Defined clear instructions for reporting vulnerabilities via GHSA.
- Established strict SLAs:
  - **Acknowledgment:** Within 48 hours of submission.
  - **Triage & ETA:** Within 5 business days.
- Documented the Bug Bounty Program rules and scope regarding the up to $1,000,000 reward tier.
- Outlined expectations for responsible disclosure.

By merging this PR, the maintainers commit to these SLAs, ensuring that future security reports are handled professionally and transparently, restoring researcher confidence in the disclosure process.