### PR TITLE
refactor: simplify Go code and modernize test helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 mixin
+.worktrees/

--- a/common/encoding.go
+++ b/common/encoding.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+	"maps"
 	"slices"
-	"sort"
 
 	"github.com/MixinNetwork/mixin/crypto"
 )
@@ -217,21 +217,10 @@ func (enc *Encoder) EncodeOutput(o *Output) {
 }
 
 func (enc *Encoder) EncodeSignatures(sm map[uint16]*crypto.Signature) {
-	ss, off := make([]struct {
-		Index uint16
-		Sig   *crypto.Signature
-	}, len(sm)), 0
-	for j, sig := range sm {
-		ss[off].Index = j
-		ss[off].Sig = sig
-		off += 1
-	}
-	sort.Slice(ss, func(i, j int) bool { return ss[i].Index < ss[j].Index })
-
-	enc.WriteInt(len(ss))
-	for _, sp := range ss {
-		enc.WriteUint16(sp.Index)
-		enc.Write(sp.Sig[:])
+	enc.WriteInt(len(sm))
+	for _, index := range slices.Sorted(maps.Keys(sm)) {
+		enc.WriteUint16(index)
+		enc.Write(sm[index][:])
 	}
 }
 

--- a/common/encoding_test.go
+++ b/common/encoding_test.go
@@ -57,7 +57,7 @@ func BenchmarkTransactionCodec(b *testing.B) {
 
 	b.Run("Marshal", func(b *testing.B) {
 		b.ReportAllocs()
-		for range b.N {
+		for b.Loop() {
 			if len(ver.Marshal()) != len(encoded) {
 				b.Fatal("unexpected transaction size")
 			}
@@ -65,7 +65,7 @@ func BenchmarkTransactionCodec(b *testing.B) {
 	})
 	b.Run("Unmarshal", func(b *testing.B) {
 		b.ReportAllocs()
-		for range b.N {
+		for b.Loop() {
 			if _, err := UnmarshalVersionedTransaction(encoded); err != nil {
 				b.Fatal(err)
 			}

--- a/common/snapshot_test.go
+++ b/common/snapshot_test.go
@@ -159,7 +159,7 @@ func benchmarkSnapshot(b *testing.B, s *SnapshotWithTopologicalOrder) {
 	for _, n := range []int{1, 4, 16, 64, 256} {
 		b.Run(fmt.Sprint(n), func(b *testing.B) {
 			b.ReportAllocs()
-			for i := 0; i < b.N; i++ {
+			for b.Loop() {
 				buf := s.VersionedMarshal()
 				s, err := UnmarshalVersionedSnapshot(buf)
 				if err != nil {

--- a/crypto/batch_test.go
+++ b/crypto/batch_test.go
@@ -20,7 +20,7 @@ func BenchmarkVerifyBatch(b *testing.B) {
 				pubs = append(pubs, &pub)
 				sigs = append(sigs, &sig)
 			}
-			for i := 0; i < b.N/n; i++ {
+			for b.Loop() {
 				if !BatchVerify(msg, pubs, sigs) {
 					b.Fatal("batch verification")
 				}

--- a/crypto/cosi_test.go
+++ b/crypto/cosi_test.go
@@ -67,7 +67,7 @@ func TestCosiAggregateSigning(t *testing.T) {
 	require.Equal(masks, cosi.Keys())
 
 	responses := make(map[int]*[32]byte)
-	for i := 0; i < len(masks); i++ {
+	for i := range masks {
 		s, err := cosi.Response(keys[masks[i]], randKeys[i], publics, message)
 		require.Nil(err)
 		responses[masks[i]] = s

--- a/crypto/hash_test.go
+++ b/crypto/hash_test.go
@@ -51,7 +51,7 @@ func benchmarkHash(b *testing.B, legacy bool) {
 		}
 		b.Run(fmt.Sprint(n), func(b *testing.B) {
 			b.ReportAllocs()
-			for i := 0; i < b.N; i++ {
+			for b.Loop() {
 				if legacy {
 					Sha256Hash([]byte(msg))
 				} else {

--- a/crypto/point_test.go
+++ b/crypto/point_test.go
@@ -50,8 +50,7 @@ func BenchmarkDecodePointCached(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	b.ResetTimer()
-	for range b.N {
+	for b.Loop() {
 		point, err := decodePoint(key[:])
 		if err != nil || point.Equal(edwards25519.NewIdentityPoint()) == 1 {
 			b.Fatal(err)
@@ -62,8 +61,7 @@ func BenchmarkDecodePointCached(b *testing.B) {
 func BenchmarkDecodePointUncached(b *testing.B) {
 	key := NewKeyFromSeed(testSeed(92)).Public()
 
-	b.ResetTimer()
-	for range b.N {
+	for b.Loop() {
 		point, err := edwards25519.NewIdentityPoint().SetBytes(key[:])
 		if err != nil || !isPrimeOrderPoint(point) || !bytes.Equal(key[:], point.Bytes()) {
 			b.Fatal(err)

--- a/docs/superpowers/plans/2026-09-01-go-1.27-modernization.md
+++ b/docs/superpowers/plans/2026-09-01-go-1.27-modernization.md
@@ -1,0 +1,471 @@
+# Go 1.27 Modernization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Modernize Mixin Kernel for Go 1.27, make version injection non-destructive, and give P2P goroutines prompt, explicit cancellation without changing protocol behavior.
+
+**Architecture:** Execute three independently testable layers: behavior-preserving language/tooling rewrites, linker-based build-version injection, then context-owned P2P lifecycle changes. Existing encoding and protocol tests remain the compatibility oracle; lifecycle behavior gets focused tests before production changes.
+
+**Tech Stack:** Go 1.27.0, standard library (`context`, `sync`, `testing/synctest`, `time`), Make, testify, QUIC via the existing quic-go dependency.
+
+**Spec:** `docs/superpowers/specs/2026-09-01-go-1.27-modernization-design.md`
+
+## Global Constraints
+
+- Preserve consensus behavior, network encodings, storage encodings, JSON field names, and public function signatures.
+- Do not migrate protocol code wholesale to `encoding/json/v2`.
+- Do not introduce experimental SIMD, unsafe optimizations, lock-free structures, pools, or speculative caching.
+- Do not change consensus timing constants, retry policy, peer selection, message ordering, database schemas, or encoded bytes.
+- Keep `MetricPool` exported counter fields as `uint32` to preserve its public type surface.
+- Preserve the pre-existing unstaged `go.sum` modification and never include it in task commits.
+- Use Go 1.27.0 for every build, test, race run, and benchmark comparison.
+
+---
+
+### Task 1: Behavior-preserving Go 1.27 rewrites
+
+**Files:**
+- Modify: `common/campaign_test.go`
+- Modify: `common/coverage_test.go`
+- Modify: `common/decoding_truncation_test.go`
+- Modify: `common/encoding.go`
+- Modify: `common/encoding_test.go`
+- Modify: `common/guard_branches_test.go`
+- Modify: `common/snapshot_test.go`
+- Modify: `common/transaction_test.go`
+- Modify: `common/utxo.go`
+- Modify: `common/version.go`
+- Modify: `crypto/batch_test.go`
+- Modify: `crypto/hash_test.go`
+- Modify: `crypto/point_test.go`
+- Modify: `kernel/node.go`
+- Modify: `kernel/round.go`
+- Modify: `rpc/consensus_test.go`
+- Modify: `rpc/internal/server/info.go`
+- Modify: `rpc/internal/server/node.go`
+- Modify: `storage/badger_graph.go`
+- Modify: `storage/badger_node.go`
+- Modify: `storage/badger_validation.go`
+- Modify: `storage/coverage_test.go`
+- Modify: `storage/error_paths_test.go`
+- Modify: `storage/round_error_paths_test.go`
+- Modify: `storage/state_guards_test.go`
+- Modify: `storage/transaction_error_paths_test.go`
+- Modify: `util/base58/base58bench_test.go`
+
+**Interfaces:**
+- Consumes: Existing composite types and benchmark functions; no new production interface.
+- Produces: Go 1.27 composite literals and benchmarks using `(*testing.B).Loop()` with unchanged operations per iteration.
+
+- [ ] **Step 1: Record focused compatibility and benchmark baselines**
+
+Run:
+
+```bash
+go test ./common ./crypto ./storage ./util/base58
+go test -run '^$' -bench 'Benchmark(TransactionCodec|SnapshotMarshal|Hash|VerifyBatch|DecodePoint|Base58)' -benchmem -count=5 ./common ./crypto ./util/base58
+```
+
+Expected: all tests pass; retain the complete benchmark output for final comparison.
+
+- [ ] **Step 2: Apply the promoted-field modernizer and inspect its exact scope**
+
+Run:
+
+```bash
+go fix -embedlit ./...
+gofmt -w common storage
+git diff --check
+```
+
+Expected: only promoted embedded-field initializers change; no type declarations, encoders, marshaling functions, or constants change.
+
+- [ ] **Step 3: Convert conventional benchmarks to `b.Loop()`**
+
+Use this shape in ordinary benchmark bodies:
+
+```go
+for b.Loop() {
+	result := operation(input)
+	if !valid(result) {
+		b.Fatal("invalid benchmark result")
+	}
+}
+```
+
+For `BenchmarkVerifyBatch`, make one `b.Loop()` iteration call `BatchVerify` once for the selected batch size. Do not divide by `b.N`; the sub-benchmark name already carries the batch size. Remove obsolete `b.ResetTimer()` calls because setup before the first `b.Loop()` iteration is excluded automatically.
+
+- [ ] **Step 4: Apply only unambiguous local idioms**
+
+Replace index-only integer loops with `for i := range n` and basic-field `sort.Slice` calls with `slices.SortFunc` only where the comparator is a direct ordered-field comparison. Preserve stable/unstable sorting behavior and skip conversions whose comparator has secondary logic. Replace split/index parsing only when the existing code's malformed-input behavior is explicitly preserved.
+
+- [ ] **Step 5: Verify the layer**
+
+Run:
+
+```bash
+gofmt -w common crypto kernel rpc storage util/base58
+go test ./common ./crypto ./kernel ./rpc/internal/server ./storage ./util/base58
+go vet ./common ./crypto ./kernel ./rpc/internal/server ./storage ./util/base58
+git diff --check
+```
+
+Expected: all commands pass and `git diff -- go.sum` remains identical to the pre-task user change.
+
+- [ ] **Step 6: Commit the modernization layer**
+
+```bash
+git add common crypto kernel rpc storage util/base58
+git commit -m "refactor: modernize code for Go 1.27"
+```
+
+Before committing, verify `git diff --cached --name-only` does not list `go.sum`.
+
+---
+
+### Task 2: Non-destructive build-version injection
+
+**Files:**
+- Modify: `config/reader.go:10-15`
+- Modify: `Makefile:1-6`
+- Create: `main_test.go`
+
+**Interfaces:**
+- Consumes: `config.BuildVersion string`, read by `main()` and urfave/cli.
+- Produces: Linker-overridable `var BuildVersion string` with default value `v0.19.6-BUILD_VERSION`; Make variable `BUILD_VERSION` passed through `-ldflags -X`.
+
+- [ ] **Step 1: Write the failing linker-injection test**
+
+Create `main_test.go`:
+
+```go
+package main
+
+import (
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildVersionCanBeInjected(t *testing.T) {
+	const version = "v0.19.6-testrev"
+	cmd := exec.CommandContext(
+		t.Context(),
+		"go", "run",
+		"-ldflags", "-X github.com/MixinNetwork/mixin/config.BuildVersion="+version,
+		".", "--version",
+	)
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(output))
+	require.Contains(t, string(output), version)
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails with the constant**
+
+Run: `go test . -run TestBuildVersionCanBeInjected -v`
+
+Expected: FAIL because linker `-X` cannot replace the current constant and `main` rejects the placeholder.
+
+- [ ] **Step 3: Make the version linker-overridable and remove source editing from Make**
+
+In `config/reader.go`, leave true constants in the constant block and declare:
+
+```go
+var BuildVersion = "v0.19.6-BUILD_VERSION"
+```
+
+Replace the Makefile body with:
+
+```make
+BUILD_VERSION ?= v0.19.6-$(shell git rev-parse --short HEAD)
+LDFLAGS := -X github.com/MixinNetwork/mixin/config.BuildVersion=$(BUILD_VERSION)
+
+.PHONY: all
+all:
+	CGO_ENABLED=0 go build -ldflags "$(LDFLAGS)" -o mixin
+```
+
+- [ ] **Step 4: Run the focused test and verify Make leaves tracked source untouched**
+
+Run:
+
+```bash
+go test . -run TestBuildVersionCanBeInjected -v
+before=$(git diff -- config/reader.go)
+make
+test "$before" = "$(git diff -- config/reader.go)"
+./mixin --version
+```
+
+Expected: test passes; Make creates no `config/reader.go--`; the diff is unchanged by Make; version output contains `v0.19.6-<current-short-revision>`.
+
+- [ ] **Step 5: Commit the build layer**
+
+```bash
+git add Makefile config/reader.go main_test.go
+git commit -m "build: inject version without editing source"
+```
+
+Before committing, verify `git diff --cached --name-only` contains exactly those three paths.
+
+---
+
+### Task 3: Cancellable wait primitive
+
+**Files:**
+- Create: `p2p/lifecycle.go`
+- Create: `p2p/lifecycle_test.go`
+
+**Interfaces:**
+- Consumes: `context.Context`, `time.Duration`.
+- Produces: `func waitContext(ctx context.Context, duration time.Duration) bool`, returning `true` when the duration elapses and `false` when cancellation wins.
+
+- [ ] **Step 1: Write failing cancellation and virtual-time tests**
+
+Create `p2p/lifecycle_test.go`:
+
+```go
+package p2p
+
+import (
+	"context"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWaitContextCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	require.False(t, waitContext(ctx, time.Hour))
+}
+
+func TestWaitContextElapsed(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		require.True(t, waitContext(t.Context(), time.Hour))
+	})
+}
+```
+
+- [ ] **Step 2: Run tests to verify the helper is missing**
+
+Run: `go test ./p2p -run 'TestWaitContext(Canceled|Elapsed)' -v`
+
+Expected: FAIL with `undefined: waitContext`.
+
+- [ ] **Step 3: Implement the minimal timer helper**
+
+Create `p2p/lifecycle.go`:
+
+```go
+package p2p
+
+import (
+	"context"
+	"time"
+)
+
+func waitContext(ctx context.Context, duration time.Duration) bool {
+	timer := time.NewTimer(duration)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
+}
+```
+
+- [ ] **Step 4: Run focused tests and commit**
+
+```bash
+gofmt -w p2p/lifecycle.go p2p/lifecycle_test.go
+go test ./p2p -run 'TestWaitContext(Canceled|Elapsed)' -v
+git add p2p/lifecycle.go p2p/lifecycle_test.go
+git commit -m "test: add cancellable P2P waits"
+```
+
+Expected: focused tests pass; staged paths do not include `go.sum`.
+
+---
+
+### Task 4: Context-owned P2P lifecycle
+
+**Files:**
+- Modify: `p2p/peer.go:15-440`
+- Modify: `p2p/sync.go:65-175`
+- Modify: `p2p/lifecycle_test.go`
+- Modify: `p2p/coverage_test.go:940-1040`
+
+**Interfaces:**
+- Consumes: `waitContext(context.Context, time.Duration) bool` from Task 3 and existing `NewPeer`, `Teardown`, `disconnect`, QUIC transport interfaces.
+- Produces: Internal `Peer.cancel context.CancelFunc`; unchanged signatures for `NewPeer`, `Teardown`, `ConnectRelayer`, `ListenConsumers`, and transport methods.
+
+- [ ] **Step 1: Add failing peer ownership tests**
+
+Append to `p2p/lifecycle_test.go`:
+
+```go
+func TestPeerTeardownCancelsContext(t *testing.T) {
+	peer := NewPeer(nil, crypto.Blake3Hash([]byte("teardown")), "127.0.0.1:0", false)
+	peer.Teardown()
+	peer.Teardown()
+	require.ErrorIs(t, context.Cause(peer.ctx), context.Canceled)
+}
+
+func TestPeerDisconnectCancelsContext(t *testing.T) {
+	peer := NewPeer(nil, crypto.Blake3Hash([]byte("disconnect")), "127.0.0.1:0", false)
+	close(peer.ops)
+	close(peer.stn)
+	peer.disconnect()
+	peer.disconnect()
+	require.ErrorIs(t, context.Cause(peer.ctx), context.Canceled)
+}
+```
+
+Add imports for the existing `crypto` package. These tests specify idempotence and context ownership without real network sleeps.
+
+- [ ] **Step 2: Run the tests to verify cancellation ownership is absent**
+
+Run: `go test ./p2p -run 'TestPeer(Teardown|Disconnect)CancelsContext' -v`
+
+Expected: FAIL because `Peer` has no cancel function and neither shutdown path cancels `peer.ctx`.
+
+- [ ] **Step 3: Add the owned context and cancel function**
+
+Add to `Peer`:
+
+```go
+ctx    context.Context
+cancel context.CancelFunc
+```
+
+At the beginning of `NewPeer`, create `ctx, cancel := context.WithCancel(context.Background())`, assign both fields in the struct literal, and remove the later `peer.ctx = context.Background()` assignment. On the successful `CompareAndSwap` path, call `cancel()` first in both `Teardown` and `disconnect`.
+
+- [ ] **Step 4: Make peer.go waits and timeout selection cancellation-aware**
+
+Apply these exact ownership rules:
+
+- `ConnectRelayer` waits on `me.ctx`; return when `waitContext` is false.
+- The periodic consumer-announcement goroutine waits on `me.ctx`; return when canceled.
+- `loopSendingStream` uses a `waitSendingStream` select that also watches `p.ctx.Done()` and returns from the loop on cancellation.
+- Artificial send delay waits on `p.ctx` and exits the sending loop when canceled.
+- `authenticateNeighbor` uses an explicit timer and adds `case <-me.ctx.Done(): return nil, context.Cause(me.ctx)`.
+- When `ListenConsumers` gets an accept error after cancellation, stop instead of retrying.
+
+Use this return contract for the send wait:
+
+```go
+func (p *Peer) waitSendingStream(wait time.Duration) bool {
+	timer := time.NewTimer(wait)
+	defer timer.Stop()
+
+	select {
+	case <-p.ctx.Done():
+		return false
+	case <-p.sendWake:
+		return true
+	case <-timer.C:
+		return true
+	}
+}
+```
+
+- [ ] **Step 5: Make sync.go waits cancellation-aware**
+
+Replace the 100ms, snapshot-gap, and one-second polling sleeps with `waitContext`. Use the connection peer's context for connection-scoped work and return `context.Cause(p.ctx)` from `syncToNeighborSince` when its pacing wait is canceled. Stop `syncToNeighborLoop` and `getSyncPointOffset` immediately when either owning peer context is done. Add the `context` import only where the cancellation cause is returned.
+
+- [ ] **Step 6: Update integration tests to exercise public shutdown**
+
+In `TestConnectRelayerAndListenConsumersIntegration`, replace direct closing-flag stores with calls to the applicable `cancel`/`Teardown` path, preserving `require.Eventually` only for real QUIC completion. In the existing teardown coverage, assert `context.Cause` for the root and both child peers in addition to the closing flags.
+
+- [ ] **Step 7: Run focused tests and race detection**
+
+Run:
+
+```bash
+gofmt -w p2p/peer.go p2p/sync.go p2p/lifecycle_test.go p2p/coverage_test.go
+go test ./p2p -run 'TestWaitContext|TestPeer|TestConnectRelayerAndListenConsumersIntegration|TestSyncToNeighborLoop' -count=1 -v
+go test -race ./p2p -count=1
+```
+
+Expected: focused and full P2P race tests pass without goroutine leak symptoms, busy retry logs, data races, or real-time hour-long waits.
+
+- [ ] **Step 8: Commit the lifecycle layer**
+
+```bash
+git add p2p/peer.go p2p/sync.go p2p/lifecycle.go p2p/lifecycle_test.go p2p/coverage_test.go
+git commit -m "fix: cancel P2P work during shutdown"
+```
+
+Before committing, verify `git diff --cached --name-only` does not list `go.sum`.
+
+---
+
+### Task 5: Repository-wide verification and benchmark comparison
+
+**Files:**
+- Modify only files required to fix a demonstrated regression from the commands below.
+
+**Interfaces:**
+- Consumes: The completed modernization, build, and lifecycle layers.
+- Produces: Verification evidence; no new interface.
+
+- [ ] **Step 1: Run formatting, diff, module, and static checks**
+
+```bash
+test -z "$(gofmt -l $(git diff --name-only 616887e4..HEAD -- '*.go'))"
+git diff --check
+go mod verify
+go mod tidy -diff
+go vet ./...
+```
+
+Expected: all commands pass; tidy emits no diff.
+
+- [ ] **Step 2: Run the complete test suite**
+
+```bash
+go test ./...
+CGO_ENABLED=0 go test -skip TestConsensus -count=1 ./...
+```
+
+Expected: all packages pass. Record package timings, especially `rpc` and `storage`.
+
+- [ ] **Step 3: Run CI consensus coverage**
+
+```bash
+CGO_ENABLED=0 MIXIN_TX_SNAPSHOT_TRACE=1 ELECTION=true METRICS=true INPUT=1000 go test -timeout=7m -count=1 -v ./rpc
+```
+
+Expected: RPC consensus suite passes within seven minutes.
+
+- [ ] **Step 4: Compare benchmarks under equivalent conditions**
+
+Run the same command used in Task 1:
+
+```bash
+go test -run '^$' -bench 'Benchmark(TransactionCodec|SnapshotMarshal|Hash|VerifyBatch|DecodePoint|Base58)' -benchmem -count=5 ./common ./crypto ./util/base58
+```
+
+Compare absolute `ns/op`, `B/op`, and `allocs/op` values against Task 1. The benchmark-loop migration changes harness semantics for batch verification; report its new unit directly rather than claiming a percentage against incompatible old units.
+
+- [ ] **Step 5: Confirm worktree and compatibility scope**
+
+```bash
+git status --short
+git diff HEAD^ -- go.mod go.sum vendor
+git log --oneline --decorate -6
+```
+
+Expected: only the user's pre-existing `go.sum` change remains unstaged; `go.mod` and `vendor` have no implementation diff; task commits remain separated by layer.
+
+- [ ] **Step 6: Commit any verification-only correction**
+
+If a verification command demonstrated a regression and required a scoped code correction, stage only the correction and its regression test, then commit with a message naming that behavior. If every verification command passes without changes, do not create an empty commit.

--- a/docs/superpowers/specs/2026-09-01-go-1.27-modernization-design.md
+++ b/docs/superpowers/specs/2026-09-01-go-1.27-modernization-design.md
@@ -1,0 +1,176 @@
+# Go 1.27 Modernization Design
+
+## Context
+
+Mixin Kernel now declares Go 1.27.0 and CI uses the same toolchain, but the
+upgrade changed the toolchain and dependencies without systematically adopting
+the modern standard-library APIs or reviewing lifecycle assumptions introduced
+since earlier Go releases.
+
+The repository is a consensus node. Correctness and wire/storage compatibility
+matter more than syntactic novelty. This work therefore separates behavior-
+preserving modernization from the higher-risk P2P lifecycle changes and rejects
+unmeasured performance rewrites.
+
+The pre-change baseline on Go 1.27.0 is:
+
+- `go vet ./...` passes.
+- `go test ./...` passes; the RPC package takes about 227 seconds.
+- `go mod verify` passes.
+- `go mod tidy -diff` produces no changes.
+- `go fix -diff ./...` proposes promoted-field composite literal rewrites in
+  13 files.
+
+The worktree already contains an unrelated `go.sum` modification. The
+implementation must preserve it and must not mix it into commits for this work.
+
+## Goals
+
+1. Adopt stable Go 1.27 idioms where they make ownership or intent clearer.
+2. Make the build reproducible without temporarily editing tracked source files.
+3. Give each P2P goroutine an explicit termination condition and make blocking
+   waits react promptly to cancellation.
+4. Preserve consensus behavior, network encodings, storage encodings, JSON field
+   names, and public function signatures.
+5. Establish test, race, vet, and benchmark evidence for the final result.
+
+## Non-goals
+
+- Migrating protocol JSON wholesale to `encoding/json/v2`.
+- Replacing project-specific hashes, addresses, or identifiers with the Go 1.27
+  `uuid` package.
+- Introducing experimental SIMD, unsafe optimizations, lock-free structures,
+  pools, or speculative caching.
+- Changing consensus timing constants, retry policy, peer selection, message
+  ordering, database schemas, or encoded bytes.
+- Upgrading third-party dependencies beyond changes required by this work.
+- Changing exported data types merely to use a newer API.
+
+## Design
+
+### Layer 1: behavior-preserving Go modernization
+
+Apply small, reviewable transformations before lifecycle changes:
+
+- Apply the Go 1.27 `embedlit` fixes for promoted embedded fields, then verify
+  that construction still initializes the same fields.
+- Replace eligible `WaitGroup.Add`/goroutine/`Done` triplets with
+  `sync.WaitGroup.Go`. Functions passed to `Go` must not panic, matching the
+  existing expectation that these goroutines complete normally.
+- Convert conventional benchmark bodies to `b.Loop()`. For benchmarks that
+  currently divide `b.N` by a batch size, restructure the benchmark so one loop
+  iteration represents one batch and report the unit explicitly rather than
+  silently changing its meaning.
+- Use integer range, `slices.SortFunc`, `strings.Cut`, or iterator APIs only when
+  missing-input behavior, ordering, allocation ownership, and error behavior are
+  unchanged.
+- Keep `MetricPool`'s exported `uint32` fields. Converting them to
+  `atomic.Uint32` would change its public field types, so the existing atomic
+  operations remain despite the newer typed-atomic idiom.
+
+Each mechanical group is formatted and tested before proceeding to the next
+group. Large unrelated formatting changes are excluded.
+
+### Layer 2: non-destructive version injection
+
+The current Makefile checks out `config/reader.go`, edits it in place with
+`sed`, builds, and checks it out again. That can overwrite local work and can
+leave a backup file on macOS.
+
+Change `config.BuildVersion` from a constant to a variable with the same default
+value. The Makefile will compute the short revision once and inject the complete
+version through Go linker `-X` flags. It will no longer invoke `git checkout` or
+modify source files. A test will cover the default version shape; the build
+workflow will verify that the injected binary reports the selected revision.
+
+The command-line output and release version format remain unchanged.
+
+### Layer 3: P2P lifecycle ownership
+
+`Peer` currently stores `context.Background()` and combines atomic closing flags,
+channel completion signals, real-time sleeps, and transport closure. The design
+will keep existing public constructors and behavior while making ownership
+explicit:
+
+- A root `Peer` owns a cancellable context created by `NewPeer` and its cancel
+  function. Peer teardown is idempotent: the successful closing transition
+  invokes cancellation before closing the listener and disconnecting neighbors.
+- Connection-scoped peer objects also own cancellation. `disconnect` performs
+  its existing idempotent transition, cancels the connection scope, and waits for
+  the sending and synchronization loops to publish completion.
+- Retry delays, periodic announcements, artificial test delays, send-loop waits,
+  authentication timeouts, and other eligible waits select on the relevant
+  context. Cancellation ends the wait without changing normal timing.
+- QUIC dial and accept operations receive the owned context so teardown unblocks
+  them. Transport close remains as a second unblock mechanism and resource
+  cleanup step.
+- Channel ownership does not change. Only the goroutine that currently owns a
+  completion channel may close it. Receivers never close shared input channels.
+- No mutex is replaced by atomics and no channel is removed unless focused tests
+  demonstrate an equivalent, simpler lifecycle.
+
+Before changing production code, focused tests will assert prompt teardown,
+idempotent teardown/disconnect, cancellation of waits, and absence of stranded
+connection loops. Tests will use synchronization events or `testing/synctest`
+where compatible; they will not rely on arbitrary sleeps.
+
+### Error handling
+
+Cancellation is an expected shutdown path. Internal loops should return or stop
+retrying when their owned context is done. Operational transport errors continue
+to be logged as today while the peer is active. Shutdown-caused errors must not
+trigger a busy retry loop.
+
+Existing externally visible errors and panic contracts remain unchanged unless
+a test proves they are accidental and the change is separately documented.
+
+### Performance policy
+
+Production performance changes require evidence. Existing crypto, encoding,
+snapshot, and base58 benchmarks will first be converted to correct Go 1.27
+benchmark structure, then recorded before and after production changes under the
+same toolchain and machine conditions.
+
+Only a scoped change with preserved correctness and a meaningful repeatable
+improvement will be retained. Transparent runtime improvements from Go 1.27 do
+not justify readability regressions.
+
+## Verification
+
+Verification proceeds from focused to broad:
+
+1. Run focused tests after each changed package.
+2. Run P2P tests with the race detector, followed by race tests for other changed
+   concurrent packages where runtime permits.
+3. Run `gofmt` on changed Go files.
+4. Run `go vet ./...`.
+5. Run `go test ./...` with the repository's normal environment.
+6. Run the CI-style test command that skips the long consensus test, then the RPC
+   consensus command with its documented environment and timeout if feasible.
+7. Run relevant benchmarks repeatedly under Go 1.27 and report absolute results,
+   variance, environment, and any trade-offs.
+8. Run `go mod verify` and `go mod tidy -diff` to ensure module metadata remains
+   consistent.
+
+## Commit structure and rollback
+
+Keep layers in separate commits when practical:
+
+1. Go 1.27 mechanical modernization and benchmark corrections.
+2. Non-destructive build-version injection.
+3. P2P lifecycle tests and cancellation implementation.
+
+This structure allows the lifecycle work to be reverted independently without
+discarding safe modernization. No commit may include the pre-existing `go.sum`
+change unless the user explicitly requests it.
+
+## Acceptance criteria
+
+- Build no longer edits or checks out tracked source files.
+- All selected Go 1.27 rewrites preserve public types and observable behavior.
+- P2P teardown cancels blocking work promptly and is safe when called repeatedly.
+- Every changed goroutine has a documented completion or cancellation path.
+- Wire bytes, storage bytes, JSON field names, and consensus behavior are
+  unchanged.
+- Vet, full tests, focused race tests, module checks, and relevant benchmarks
+  complete successfully, with results reported.

--- a/kernel/mint.go
+++ b/kernel/mint.go
@@ -260,7 +260,7 @@ func (node *Node) lastMintDistribution() *common.MintData {
 
 func poolSizeUniversal(batch int) common.Integer {
 	mint, pool := common.Zero, MintPool
-	for i := 0; i < batch/MintYearDays; i++ {
+	for range batch / MintYearDays {
 		year := MintYearPercent.Product(pool)
 		mint = mint.Add(year)
 		pool = pool.Sub(year)
@@ -281,7 +281,7 @@ func mintBatchSize(batch uint64) common.Integer {
 	if years > 10000 {
 		panic(years)
 	}
-	for i := 0; i < int(years); i++ {
+	for range years {
 		year := MintYearPercent.Product(pool)
 		pool = pool.Sub(year)
 	}

--- a/kernel/round.go
+++ b/kernel/round.go
@@ -1,9 +1,9 @@
 package kernel
 
 import (
+	"cmp"
 	"fmt"
 	"slices"
-	"sort"
 	"sync"
 
 	"github.com/MixinNetwork/mixin/common"
@@ -175,8 +175,8 @@ func (c *CacheRound) Gap() (uint64, uint64) {
 	if count == 0 {
 		return start, end
 	}
-	sort.Slice(c.Snapshots, func(i, j int) bool {
-		return c.Snapshots[i].Timestamp < c.Snapshots[j].Timestamp
+	slices.SortFunc(c.Snapshots, func(a, b *common.Snapshot) int {
+		return cmp.Compare(a.Timestamp, b.Timestamp)
 	})
 	start = c.Snapshots[0].Timestamp
 	end = c.Snapshots[count-1].Timestamp

--- a/p2p/quic_test.go
+++ b/p2p/quic_test.go
@@ -2,7 +2,6 @@ package p2p
 
 import (
 	"bytes"
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -20,7 +19,7 @@ func TestQuic(t *testing.T) {
 
 	wait := make(chan struct{})
 	go func() {
-		server, err := serverTrans.Accept(context.Background())
+		server, err := serverTrans.Accept(t.Context())
 		require.Nil(err)
 		require.NotNil(server)
 		msg, err := server.Receive()
@@ -29,7 +28,7 @@ func TestQuic(t *testing.T) {
 		wait <- struct{}{}
 	}()
 
-	client, err := NewQuicConsumer(context.Background(), listenAddr)
+	client, err := NewQuicConsumer(t.Context(), listenAddr)
 	require.Nil(err)
 	require.NotNil(client)
 	require.NotNil(client.RemoteAddr())
@@ -46,7 +45,7 @@ func TestQuicErrors(t *testing.T) {
 	_, err := NewQuicRelayer("bad-addr")
 	require.Error(err)
 
-	_, err = NewQuicConsumer(context.Background(), "bad-addr")
+	_, err = NewQuicConsumer(t.Context(), "bad-addr")
 	require.Error(err)
 
 	err = (&QuicClient{}).Send(nil)
@@ -59,7 +58,7 @@ func TestQuicErrors(t *testing.T) {
 	closedRelayer, err := NewQuicRelayer("127.0.0.1:0")
 	require.Nil(err)
 	require.NoError(closedRelayer.Close())
-	_, err = closedRelayer.Accept(context.Background())
+	_, err = closedRelayer.Accept(t.Context())
 	require.ErrorContains(err, "quic.Accept")
 
 	serverTrans, err := NewQuicRelayer("127.0.0.1:0")
@@ -69,12 +68,12 @@ func TestQuicErrors(t *testing.T) {
 
 	accept := make(chan *QuicClient, 1)
 	go func() {
-		server, err := serverTrans.Accept(context.Background())
+		server, err := serverTrans.Accept(t.Context())
 		require.Nil(err)
 		accept <- server.(*QuicClient)
 	}()
 
-	client, err := NewQuicConsumer(context.Background(), serverTrans.listener.Addr().String())
+	client, err := NewQuicConsumer(t.Context(), serverTrans.listener.Addr().String())
 	require.Nil(err)
 	require.Nil(client.Send([]byte("accept")))
 	server := <-accept
@@ -91,12 +90,12 @@ func TestQuicErrors(t *testing.T) {
 
 	accept2 := make(chan *QuicClient, 1)
 	go func() {
-		server, err := serverTrans2.Accept(context.Background())
+		server, err := serverTrans2.Accept(t.Context())
 		require.Nil(err)
 		accept2 <- server.(*QuicClient)
 	}()
 
-	client2, err := NewQuicConsumer(context.Background(), serverTrans2.listener.Addr().String())
+	client2, err := NewQuicConsumer(t.Context(), serverTrans2.listener.Addr().String())
 	require.Nil(err)
 	require.Nil(client2.Send([]byte("accept")))
 	server2 := <-accept2

--- a/rpc/consensus_test.go
+++ b/rpc/consensus_test.go
@@ -170,11 +170,7 @@ func testConsensus(t *testing.T, extrenalRelayers bool) {
 			util.CloseOrPanic(server)
 		}
 		for _, n := range append(instances, relayerInstances...) {
-			wg.Add(1)
-			go func(node *kernel.Node) {
-				node.Teardown()
-				wg.Done()
-			}(n)
+			wg.Go(n.Teardown)
 		}
 		wg.Wait()
 	}()
@@ -193,7 +189,7 @@ func testConsensus(t *testing.T, extrenalRelayers bool) {
 	genesisAmount := (13439 + 3.5) / float64(INPUTS)
 	domainAddress := accounts[0].String()
 	deposits := make([]*common.VersionedTransaction, 0)
-	for i := 0; i < INPUTS; i++ {
+	for i := range INPUTS {
 		raw := fmt.Sprintf(`{"version":5,"asset":"a99c2e0e2b1da4d648755ef19bd95139acbbe6564cfb06dec7cd34931ca72cdc","inputs":[{"deposit":{"chain":"8dd50817c082cdcdd6f167514928767a4b52426997bd6d4930eca101c5ff8a27","asset_key":"0xa974c709cfb4566686553a20790685a47aceaa33","transaction":"0xc7c1132b58e1f64c263957d7857fe5ec5294fce95d30dcd64efef71da1%06d","index":0,"amount":"%f"}}],"outputs":[{"type":0,"amount":"%f","script":"fffe01","accounts":["%s"]}]}`, i, genesisAmount, genesisAmount, domainAddress)
 		randT := int(time.Now().UnixNano()) % len(nodes)
 		tx, err := testSignTransaction(nodes[randT].Host, accounts[0], raw)
@@ -735,8 +731,7 @@ func testSendDummyTransactions(nodes []*Node, domain common.Address, inputs []*c
 
 	var wg sync.WaitGroup
 	for i, node := range nodes {
-		wg.Add(1)
-		go func(i int, node *Node) {
+		wg.Go(func() {
 			raw, _ := json.Marshal(map[string]any{
 				"version": 2,
 				"asset":   "a99c2e0e2b1da4d648755ef19bd95139acbbe6564cfb06dec7cd34931ca72cdc",
@@ -755,8 +750,7 @@ func testSendDummyTransactions(nodes []*Node, domain common.Address, inputs []*c
 			ver := common.VersionedTransaction{SignedTransaction: *tx}
 			hash, _ := testSendTransaction(node.Host, hex.EncodeToString(ver.Marshal()))
 			outputs[i] = &common.Input{Index: 0, Hash: hash}
-			wg.Done()
-		}(i, node)
+		})
 	}
 	wg.Wait()
 
@@ -926,7 +920,7 @@ func testBuildPledgeInput(t *testing.T, nodes []*Node, domain common.Address, ut
 		})
 	}
 	outputs := []map[string]any{}
-	for i := 0; i < NODES; i++ {
+	for range NODES {
 		outputs = append(outputs, map[string]any{
 			"type":     0,
 			"amount":   common.NewIntegerFromString("3.5").Div(NODES),
@@ -1218,7 +1212,7 @@ func setupTestNet(root string, extrenalRelayers bool) ([]common.Address, []commo
 	var relayerInstances []*kernel.Node
 	var relayerServers []*http.Server
 
-	for i := 0; i < NODES; i++ {
+	for i := range NODES {
 		signers = append(signers, testDetermineAccountByIndex(i, "SIGNER"))
 		payees = append(payees, testDetermineAccountByIndex(i, "PAYEE"))
 		custodians = append(custodians, testDetermineAccountByIndex(i, "CUSTODIAN"))
@@ -1469,7 +1463,7 @@ func testVerifySnapshots(require *require.Assertions, nodes []*Node, expectedTra
 		}
 		txs, snapshots = collectSnapshotSets(filters)
 		consistent := true
-		for i := 0; i < len(filters)-1; i++ {
+		for i := range len(filters) - 1 {
 			if !snapshotKeysEqual(filters[i], filters[i+1]) {
 				consistent = false
 				break
@@ -1480,7 +1474,7 @@ func testVerifySnapshots(require *require.Assertions, nodes []*Node, expectedTra
 		}
 		time.Sleep(time.Second)
 	}
-	for i := 0; i < len(filters)-1; i++ {
+	for i := range len(filters) - 1 {
 		a, b := filters[i], filters[i+1]
 		m, n := make(map[string]bool), make(map[string]bool)
 		for k := range a {

--- a/rpc/internal/server/info.go
+++ b/rpc/internal/server/info.go
@@ -1,14 +1,16 @@
 package server
 
 import (
+	"cmp"
 	"fmt"
-	"sort"
+	"slices"
 	"time"
 
 	"github.com/MixinNetwork/mixin/common"
 	"github.com/MixinNetwork/mixin/config"
 	"github.com/MixinNetwork/mixin/crypto"
 	"github.com/MixinNetwork/mixin/kernel"
+	"github.com/MixinNetwork/mixin/p2p"
 	"github.com/MixinNetwork/mixin/storage"
 )
 
@@ -98,7 +100,9 @@ func getInfo(store storage.Store, node *kernel.Node) (map[string]any, error) {
 
 func dumpGraphHead(node *kernel.Node, _ []any) (any, error) {
 	rounds := node.BuildGraph()
-	sort.Slice(rounds, func(i, j int) bool { return fmt.Sprint(rounds[i].NodeId) < fmt.Sprint(rounds[j].NodeId) })
+	slices.SortFunc(rounds, func(a, b *p2p.SyncPoint) int {
+		return cmp.Compare(fmt.Sprint(a.NodeId), fmt.Sprint(b.NodeId))
+	})
 	return rounds, nil
 }
 

--- a/rpc/internal/server/node.go
+++ b/rpc/internal/server/node.go
@@ -1,9 +1,10 @@
 package server
 
 import (
+	"cmp"
 	"errors"
 	"fmt"
-	"sort"
+	"slices"
 	"strconv"
 	"time"
 
@@ -44,7 +45,9 @@ func listAllNodes(store storage.Store, node *kernel.Node, params []any) ([]map[s
 }
 
 func peerNeighbors(peers []*p2p.Peer) []map[string]any {
-	sort.Slice(peers, func(i, j int) bool { return peers[i].IdForNetwork.String() < peers[j].IdForNetwork.String() })
+	slices.SortFunc(peers, func(a, b *p2p.Peer) int {
+		return cmp.Compare(a.IdForNetwork.String(), b.IdForNetwork.String())
+	})
 	data := make([]map[string]any, 0)
 	for _, p := range peers {
 		data = append(data, map[string]any{

--- a/storage/badger_graph.go
+++ b/storage/badger_graph.go
@@ -1,10 +1,11 @@
 package storage
 
 import (
+	"cmp"
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
-	"sort"
+	"slices"
 
 	"github.com/MixinNetwork/mixin/common"
 	"github.com/MixinNetwork/mixin/config"
@@ -211,7 +212,9 @@ func readSnapshotsForNodeRound(txn *badger.Txn, nodeId crypto.Hash, round uint64
 		snapshots = append(snapshots, s)
 	}
 
-	sort.Slice(snapshots, func(i, j int) bool { return snapshots[i].Timestamp < snapshots[j].Timestamp })
+	slices.SortFunc(snapshots, func(a, b *common.SnapshotWithTopologicalOrder) int {
+		return cmp.Compare(a.Timestamp, b.Timestamp)
+	})
 	return snapshots, nil
 }
 

--- a/storage/badger_node.go
+++ b/storage/badger_node.go
@@ -1,9 +1,10 @@
 package storage
 
 import (
+	"cmp"
 	"encoding/binary"
 	"fmt"
-	"sort"
+	"slices"
 
 	"github.com/MixinNetwork/mixin/common"
 	"github.com/MixinNetwork/mixin/config"
@@ -66,8 +67,8 @@ func readAllNodes(txn *badger.Txn, threshold uint64, withState bool) []*common.N
 	for _, n := range filter {
 		nodes = append(nodes, n)
 	}
-	sort.Slice(nodes, func(i, j int) bool {
-		return nodes[i].Timestamp < nodes[j].Timestamp
+	slices.SortFunc(nodes, func(a, b *common.Node) int {
+		return cmp.Compare(a.Timestamp, b.Timestamp)
 	})
 	return nodes
 }

--- a/storage/state_guards_test.go
+++ b/storage/state_guards_test.go
@@ -287,8 +287,8 @@ func TestMintRoundAndCustodianCorruption(t *testing.T) {
 		for i := range nodes {
 			node := make([]byte, 353)
 			node[0] = 1
-			for field := 0; field < 4; field++ {
-				for j := 0; j < 32; j++ {
+			for field := range 4 {
+				for j := range 32 {
 					node[1+field*32+j] = byte(i*4 + field + 1)
 				}
 			}

--- a/util/base58/base58.go
+++ b/util/base58/base58.go
@@ -131,7 +131,7 @@ func Encode(b []byte) string {
 
 	// reverse
 	alen := len(answer)
-	for i := 0; i < alen/2; i++ {
+	for i := range alen / 2 {
 		answer[i], answer[alen-1-i] = answer[alen-1-i], answer[i]
 	}
 

--- a/util/base58/base58bench_test.go
+++ b/util/base58/base58bench_test.go
@@ -20,28 +20,28 @@ var (
 
 func BenchmarkBase58Encode_5K(b *testing.B) {
 	b.SetBytes(int64(len(raw5k)))
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		base58.Encode(raw5k)
 	}
 }
 
 func BenchmarkBase58Encode_100K(b *testing.B) {
 	b.SetBytes(int64(len(raw100k)))
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		base58.Encode(raw100k)
 	}
 }
 
 func BenchmarkBase58Decode_5K(b *testing.B) {
 	b.SetBytes(int64(len(encoded5k)))
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		base58.Decode(encoded5k)
 	}
 }
 
 func BenchmarkBase58Decode_100K(b *testing.B) {
 	b.SetBytes(int64(len(encoded100k)))
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		base58.Decode(encoded100k)
 	}
 }


### PR DESCRIPTION
Simplify Go code using typed `slices`/`cmp` sorting, sorted map keys, and integer ranges while preserving signature encoding order and the existing sort comparisons. Update tests and benchmarks to use `testing.B.Loop`, `testing.T.Context`, and `sync.WaitGroup.Go`.

The branch also includes the existing Go modernization design and implementation plan, plus the local worktree ignore entry. The code changes in this PR cover these language and test helper simplifications; the broader build and P2P lifecycle work described in the plan remains separate.

`BenchmarkVerifyBatch` now reports time and allocations per batch. Its previous `b.N/n` loop approximated per-signature measurements, so results for batch sizes greater than one are not directly comparable with historical numbers.

Validation on Go 1.27.1, macOS arm64:

- `CGO_ENABLED=0 go test ./...` (including consensus integration tests)
- `go vet ./...`
- `CGO_ENABLED=0 go build -o /private/tmp/mixin-pr-review .`
- `go test ./common ./crypto ./util/base58 -run '^$' -bench 'Benchmark(TransactionCodec|Snapshot|VerifyBatch|Hash|DecodePoint|Base58)' -benchtime=1x` (benchmark smoke test)
- `git diff --check` and formatting checks

The commands used a temporary `GOSUMDB=sum.golang.org` override to allow verification of the downloaded Go 1.27.1 toolchain.
